### PR TITLE
Fix: The PM10 value always stays the same in the main view

### DIFF
--- a/source/view/AqicnMainView.mc
+++ b/source/view/AqicnMainView.mc
@@ -70,7 +70,6 @@ class AqicnMainView extends WatchUi.View {
                 pm10View.setColor(fgColor);
                 pm10View.setText(data.pm10.toString());
             }
-            pm10View.setText("17");
 
             // Call the parent onUpdate function to redraw the layout
             View.onUpdate(dc);


### PR DESCRIPTION
It seems that there was a debug line left in the final version of the code, so the PM10 value never actually got updated in the main view.